### PR TITLE
Disable default help command

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ bot_token = 'your-bot-token'
 
 intents = Intents.all()
 intents.messages = True
-bot = commands.Bot(command_prefix='!', intents=intents)
+bot = commands.Bot(command_prefix='!', intents=intents, help_command=None)
 
 status = cycle(['psyduck orz', 'I am a bot', 'Ask me anything'])
 


### PR DESCRIPTION
The PR will fix #5 
<img width="758" alt="image" src="https://github.com/intrepidbird/psyduck/assets/20255031/5fae939a-3298-4544-9868-b39a384f51d2">

As you can see, the bot works properly after disabling the default help command.